### PR TITLE
Move sicp.d.ts definitions into the declare module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+
+# Normally one wouldn't add a lock file to a non-library project.
+# However, we already have the npm lock file. So no need for two.
+yarn.lock 

--- a/sicp.d.ts
+++ b/sicp.d.ts
@@ -10,7 +10,7 @@ declare module 'sicp' {
     export function apply_in_underlying_javascript(f: any, args: any): any;
     export function pair<H,T>(head: H, tail: T): Pair<H, T>;
     export function stringify(value: any): string;
-    export function is_null(value: any): boolean;
+    export function is_null(value: any): value is null;
     export function error(...args: any[]): any;
     export function math_abs(value: number): number;
     export const math_PI: number;

--- a/sicp.d.ts
+++ b/sicp.d.ts
@@ -1,27 +1,26 @@
-declare module 'sicp';
+declare module 'sicp' {
+    export type Pair<H, T> = [H, T];
+    export type List<T> = [T, List<T>] | null;
 
-type Pair<H, T> = [H, T];
-type List<T> = [T, List<T>] | null;
-
-declare function is_boolean(value: any): boolean;
-declare function set_head<H, T>(pair: Pair<H, T>, elem: H): Pair<H, T>;
-declare function is_pair(value: any): boolean;
-declare function list_ref(list: any, index: number): any;
-declare function apply_in_underlying_javascript(f: any, args: any): any;
-declare function pair<H,T>(head: H, tail: T): Pair<H, T>;
-declare function stringify(value: any): string;
-declare function is_null(value: any): boolean;
-declare function error(...args: [any]): any;
-declare function math_abs(value: number): number;
-declare const math_PI: number;
-declare const math_E: number;
-declare function display(...x: any[]): any;
-declare function map<H, T>(fun: (from: H) => T, list: List<H>): List<T>;
-declare function accumulate(x: any): any;
-declare function parse(x: any): any;
-declare function append<T>(a: List<T>, b: List<T>): List<T>;
-declare function head<H, T>(pair: Pair<H, T>): H;
-declare function list<T>(...elems: [T]): List<T>;
-declare function tail<H, T>(pair: Pair<H, T>): T;
-
+    export function is_boolean(value: any): boolean;
+    export function set_head<H, T>(pair: Pair<H, T>, elem: H): Pair<H, T>;
+    export function is_pair(value: any): boolean;
+    export function list_ref(list: any, index: number): any;
+    export function apply_in_underlying_javascript(f: any, args: any): any;
+    export function pair<H,T>(head: H, tail: T): Pair<H, T>;
+    export function stringify(value: any): string;
+    export function is_null(value: any): boolean;
+    export function error(...args: [any]): any;
+    export function math_abs(value: number): number;
+    export const math_PI: number;
+    export const math_E: number;
+    export function display(...x: any[]): any;
+    export function map<H, T>(fun: (from: H) => T, list: List<H>): List<T>;
+    export function accumulate(x: any): any;
+    export function parse(x: any): any;
+    export function append<T>(a: List<T>, b: List<T>): List<T>;
+    export function head<H, T>(pair: Pair<H, T>): H;
+    export function list<T>(...elems: [T]): List<T>;
+    export function tail<H, T>(pair: Pair<H, T>): T;
+}
 

--- a/sicp.d.ts
+++ b/sicp.d.ts
@@ -11,7 +11,7 @@ declare module 'sicp' {
     export function pair<H,T>(head: H, tail: T): Pair<H, T>;
     export function stringify(value: any): string;
     export function is_null(value: any): boolean;
-    export function error(...args: [any]): any;
+    export function error(...args: any[]): any;
     export function math_abs(value: number): number;
     export const math_PI: number;
     export const math_E: number;
@@ -21,10 +21,7 @@ declare module 'sicp' {
     export function parse(x: any): any;
     export function append<T>(a: List<T>, b: List<T>): List<T>;
     export function head<H, T>(pair: Pair<H, T>): H;
+    export function list<T>(...elems: T[]): List<T>;
     export function tail<H, T>(pair: Pair<H, T>): T;
-
-    export function list<T>(...elems: [T]): List<T>;
-    // Because the above requires at least one argument
-    export function list<T>(): List<T>; 
 }
 

--- a/sicp.d.ts
+++ b/sicp.d.ts
@@ -5,6 +5,10 @@ declare module 'sicp' {
     export function is_boolean(value: any): boolean;
     export function set_head<H, T>(pair: Pair<H, T>, elem: H): Pair<H, T>;
     export function is_pair(value: any): boolean;
+    export function list_ref<L extends [A, null|[B, null|[C, null|[D, null]]]], A, B, C, D>(list: L, index: 0): A;
+    export function list_ref<L extends [A, null|[B, null|[C, null|[D, null]]]], A, B, C, D>(list: L, index: 1): B;
+    export function list_ref<L extends [A, null|[B, null|[C, null|[D, null]]]], A, B, C, D>(list: L, index: 2): C;
+    export function list_ref<L extends [A, null|[B, null|[C, null|[D, null]]]], A, B, C, D>(list: L, index: 3): D;
     export function list_ref<T>(list: List<T>, index: number): T;
     export function length<T>(list: List<T>): number;
     export function apply_in_underlying_javascript(f: any, args: any): any;
@@ -21,6 +25,11 @@ declare module 'sicp' {
     export function parse(x: any): any;
     export function append<T>(a: List<T>, b: List<T>): List<T>;
     export function head<H, T>(pair: Pair<H, T>): H;
+    export function list<A>(a: A): Pair<A, null>;
+    export function list<A, B>(a: A, b: B): Pair<A, Pair<B, null>>;
+    export function list<A, B, C>(a: A, b: B, c: C): Pair<A, Pair<B, Pair<C, null>>>;
+    export function list<A, B, C, D>(a: A, b: B, c: C, d: D): Pair<A, Pair<B, Pair<C, Pair<D, null>>>>;
+    export function list<A, B, C, D, E>(a: A, b: B, c: C, d: D, e: E): Pair<A, Pair<B, Pair<C, Pair<D, Pair<E, null>>>>>;
     export function list<T>(...elems: T[]): List<T>;
     export function tail<H, T>(pair: Pair<H, T>): T;
 }

--- a/sicp.d.ts
+++ b/sicp.d.ts
@@ -5,7 +5,8 @@ declare module 'sicp' {
     export function is_boolean(value: any): boolean;
     export function set_head<H, T>(pair: Pair<H, T>, elem: H): Pair<H, T>;
     export function is_pair(value: any): boolean;
-    export function list_ref(list: any, index: number): any;
+    export function list_ref<T>(list: List<T>, index: number): T;
+    export function length<T>(list: List<T>): number;
     export function apply_in_underlying_javascript(f: any, args: any): any;
     export function pair<H,T>(head: H, tail: T): Pair<H, T>;
     export function stringify(value: any): string;
@@ -16,11 +17,14 @@ declare module 'sicp' {
     export const math_E: number;
     export function display(...x: any[]): any;
     export function map<H, T>(fun: (from: H) => T, list: List<H>): List<T>;
-    export function accumulate(x: any): any;
+    export function accumulate<A, T>(x: (a: T, b: A) => A, initial: A, list: List<T>): A;
     export function parse(x: any): any;
     export function append<T>(a: List<T>, b: List<T>): List<T>;
     export function head<H, T>(pair: Pair<H, T>): H;
-    export function list<T>(...elems: [T]): List<T>;
     export function tail<H, T>(pair: Pair<H, T>): T;
+
+    export function list<T>(...elems: [T]): List<T>;
+    // Because the above requires at least one argument
+    export function list<T>(): List<T>; 
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import * as PromptSync from "prompt-sync";
 
 const prompt: PromptSync.Prompt = PromptSync({sigint:true});
 
-import { is_boolean, set_head, is_pair, list_ref, apply_in_underlying_javascript, pair, stringify, is_null, error, math_abs, math_PI, math_E, display, map, accumulate, length, parse, append, head, list, tail } from 'sicp';
+import { List, Pair, is_boolean, set_head, is_pair, list_ref, apply_in_underlying_javascript, pair, stringify, is_null, error, math_abs, math_PI, math_E, display, map, accumulate, length, parse, append, head, list, tail } from 'sicp';
 
 type Environment = List<Frame>;
 type Frame = Pair<List<Symbol>, List<Value>>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -454,7 +454,7 @@ function eval_sequence(stmts: List<Statement>, env: Environment): Value {
 function scan_out_declarations(component: Component): List<Symbol> {
     return is_sequence(component)
            ? accumulate(append,
-                        null,
+                        list(),
                         map(scan_out_declarations,
                             sequence_statements(component)))
            : is_declaration(component)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "target": "es6",
     "module": "CommonJS",
     "sourceMap": true,
     "sourceRoot": "src",
     "outDir": "build",
-    "strict": true,
+    "strict": true
   }
 }


### PR DESCRIPTION
To get proper type-checking, we should not augment the `sicp` import. Instead we should create a new definition. This is done by moving all "declares" into the declare module. If this isn't done then TypeScript will resolve `sicp` as `any`. The result is compiling but type-unsafe code which is not useful for the refactoring stage of homework 11.
Please see https://stackoverflow.com/questions/42388217/having-error-module-name-resolves-to-an-untyped-module-at-when-writing-cu as for why this change should be made. Without this change users are shown the following:
```
Could not find a declaration file for module 'sicp'.  '[...]/mce-typed/node_modules/sicp/dist/sicp.js' implicitly has an 'any' type. Try `npm i --save-dev @types/sicp` if it exists or add a new declaration (.d.ts) file containing `declare module 'sicp';`
```
This patch makes TypeScript not treat the import as an `any` value. The patch has not been tested on TS versions older than 4.7.4. It is possible the patch isn't necessary in older releases. 
Warmest regards, Alexander Björkman